### PR TITLE
checker: rewrote checker.Run to return a Result directly instead of string and errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
 after_script:
   - go get -v github.com/alecthomas/gometalinter/...
   - gometalinter --install
-  - gometalinter --enable-all
+  - gometalinter --enable-all --disable=lll
 
 after_success:
   - rm -v jagozzi

--- a/consumers/nsca/nsca_test.go
+++ b/consumers/nsca/nsca_test.go
@@ -3,7 +3,6 @@ package nsca
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -25,9 +24,13 @@ func (fc fakeChecker) ServiceName() string {
 	return "fake-service-name"
 }
 
-func (fc fakeChecker) Run(ctx context.Context) (string, error) {
+func (fc fakeChecker) Run(ctx context.Context) plugins.Result {
 	fc.t.Fatal("fake checker should not run")
-	return "", errors.New("fake checker should not run")
+	return plugins.Result{
+		Status:  plugins.STATE_CRITICAL,
+		Message: "fake checker should never run",
+		Checker: fc,
+	}
 }
 
 func TestConsumerSendMessage(t *testing.T) {

--- a/plugins/command/command_test.go
+++ b/plugins/command/command_test.go
@@ -1,0 +1,50 @@
+package command
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rbeuque74/jagozzi/plugins"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommand(t *testing.T) {
+	// creating Command checker
+	cfg := map[string]interface{}{
+		"command": "/bin/echo HelloWorld",
+		"name":    "test-1",
+	}
+	checker, err := NewCommandChecker(cfg, nil)
+	assert.Nilf(t, err, "command checker instantiation failed: %q", err)
+
+	ctxRun, cancelFunc1 := context.WithTimeout(context.Background(), time.Second)
+	defer cancelFunc1()
+	result := checker.Run(ctxRun)
+	assert.Equal(t, plugins.STATE_OK, result.Status)
+	assert.Containsf(t, result.Message, "HelloWorld\n", "command bad message: %q", result.Message)
+
+	// bad exit code
+	cfg["command"] = "/bin/false"
+
+	checker, err = NewCommandChecker(cfg, nil)
+	assert.Nilf(t, err, "command checker instantiation failed: %q", err)
+
+	ctxRun, cancelFunc1 = context.WithTimeout(context.Background(), time.Second)
+	defer cancelFunc1()
+	result = checker.Run(ctxRun)
+	assert.Equal(t, plugins.STATE_CRITICAL, result.Status)
+	assert.Equal(t, result.Message, "command /bin/false exited with status code 1")
+
+	// timeout
+	cfg["command"] = "/bin/sleep 2"
+
+	checker, err = NewCommandChecker(cfg, nil)
+	assert.Nilf(t, err, "command checker instantiation failed: %q", err)
+
+	ctxRun, cancelFunc1 = context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancelFunc1()
+	result = checker.Run(ctxRun)
+	assert.Equal(t, plugins.STATE_CRITICAL, result.Status)
+	assert.Equal(t, result.Message, "command /bin/sleep 2 took too long to execute")
+}

--- a/plugins/factory.go
+++ b/plugins/factory.go
@@ -24,7 +24,7 @@ type WithServiceName interface {
 type Checker interface {
 	WithServiceName
 	Name() string
-	Run(context.Context) (string, error)
+	Run(context.Context) Result
 }
 
 // CheckerFactory is the function interface to creates a checker instance

--- a/plugins/result.go
+++ b/plugins/result.go
@@ -47,3 +47,17 @@ func RenderError(tmpl *template.Template, model interface{}) string {
 	}
 	return buf.String()
 }
+
+// ResultFromError generates a critical result from a checker and an error
+func ResultFromError(checker Checker, err error, prefix string) Result {
+	msg := err.Error()
+	if prefix != "" {
+		msg = prefix + ": " + msg
+	}
+
+	return Result{
+		Status:  STATE_CRITICAL,
+		Message: msg,
+		Checker: checker,
+	}
+}


### PR DESCRIPTION
Will allow control of CRITICAL / WARNING state directly from plugins> string(stdout.String())

