### PR TITLE
One shot

### DIFF
--- a/consumers/gui/gui.go
+++ b/consumers/gui/gui.go
@@ -85,7 +85,7 @@ func draw(msgs map[string]consumers.ResultWithHostname) {
 	nbMsgs := len(msgs)
 	eof := "\n"
 	i := 0
-	for _ = range msgs {
+	for range msgs {
 		tm.Println(clearLine)
 	}
 	tm.MoveCursor(1, 1)

--- a/plugins/marathon/marathon_test.go
+++ b/plugins/marathon/marathon_test.go
@@ -28,13 +28,13 @@ var mockApp = app{
 		TasksUnhealthy: 0,
 		Instances:      intPtr(2),
 		Tasks: []*marathonlib.Task{
-			&marathonlib.Task{
+			{
 				ID:        "app1",
 				AppID:     "/production/app",
 				StagedAt:  time.Now().UTC().Add(-3 * time.Hour).Format(timeFormat),
 				StartedAt: time.Now().UTC().Add(-3 * time.Hour).Format(timeFormat),
 			},
-			&marathonlib.Task{
+			{
 				ID:        "app2",
 				AppID:     "/production/app",
 				StagedAt:  time.Now().UTC().Add(-4 * time.Hour).Format(timeFormat),

--- a/utils.go
+++ b/utils.go
@@ -52,3 +52,11 @@ func applyLogLevel(level *string) {
 		log.SetLevel(log.PanicLevel)
 	}
 }
+
+func tearDownLoop(cancelFuncs []context.CancelFunc) func() {
+	return func() {
+		for _, f := range cancelFuncs {
+			f()
+		}
+	}
+}


### PR DESCRIPTION
one-shot mode allow jagozzi to run checkers one time, then exiting.
Useful when jagozzi is run from cron